### PR TITLE
Loosened coupling of Client / Server implementations

### DIFF
--- a/cpp_grpc/client.h
+++ b/cpp_grpc/client.h
@@ -23,6 +23,7 @@
 
 #include "grpc++/grpc++.h"
 #include "grpc++/impl/codegen/client_unary_call.h"
+#include "grpc++/impl/codegen/proto_utils.h"
 #include "grpc++/impl/codegen/sync_stream.h"
 
 #include "glog/logging.h"

--- a/cpp_grpc/client.h
+++ b/cpp_grpc/client.h
@@ -55,7 +55,7 @@ class Client {
                             typename RpcHandlerType::OutgoingType>::value,
                     channel_) {}
 
-  bool Read(typename RpcHandlerType::ResponseType *response) {
+  bool StreamRead(typename RpcHandlerType::ResponseType *response) {
     switch (rpc_method_.method_type()) {
       case ::grpc::internal::RpcMethod::BIDI_STREAMING:
         InstantiateClientReaderWriterIfNeeded();
@@ -64,7 +64,8 @@ class Client {
         CHECK(client_reader_);
         return client_reader_->Read(response);
       default:
-        LOG(FATAL) << "Not implemented.";
+        LOG(FATAL)
+            << "This method is for server or bidirectional streaming RPC only.";
     }
   }
 
@@ -75,7 +76,7 @@ class Client {
         std::bind(&Client<RpcHandlerType>::Reset, this));
   }
 
-  bool WritesDone() {
+  bool StreamWritesDone() {
     switch (rpc_method_.method_type()) {
       case ::grpc::internal::RpcMethod::CLIENT_STREAMING:
         InstantiateClientWriterIfNeeded();
@@ -84,11 +85,12 @@ class Client {
         InstantiateClientReaderWriterIfNeeded();
         return client_reader_writer_->WritesDone();
       default:
-        LOG(FATAL) << "Not implemented.";
+        LOG(FATAL)
+            << "This method is for client or bidirectional streaming RPC only.";
     }
   }
 
-  ::grpc::Status Finish() {
+  ::grpc::Status StreamFinish() {
     switch (rpc_method_.method_type()) {
       case ::grpc::internal::RpcMethod::CLIENT_STREAMING:
         InstantiateClientWriterIfNeeded();
@@ -100,7 +102,7 @@ class Client {
         CHECK(client_reader_);
         return client_reader_->Finish();
       default:
-        LOG(FATAL) << "Not implemented.";
+        LOG(FATAL) << "This method is for streaming RPC only.";
     }
   }
 

--- a/cpp_grpc/client.h
+++ b/cpp_grpc/client.h
@@ -19,25 +19,27 @@
 
 #include "cpp_grpc/retry.h"
 #include "cpp_grpc/rpc_handler_interface.h"
-#include "cpp_grpc/type_traits.h"
-#include "glog/logging.h"
+#include "cpp_grpc/rpc_service_method_traits.h"
+
 #include "grpc++/grpc++.h"
 #include "grpc++/impl/codegen/client_unary_call.h"
 #include "grpc++/impl/codegen/sync_stream.h"
 
-namespace cpp_grpc {
+#include "glog/logging.h"
 
-template <typename RpcHandlerType>
+namespace cpp_grpc {
+template <typename RpcServiceMethodConcept>
 class Client {
+  using RpcServiceMethod = RpcServiceMethodTraits<RpcServiceMethodConcept>;
+  using RequestType = typename RpcServiceMethod::RequestType;
+  using ResponseType = typename RpcServiceMethod::ResponseType;
+
  public:
   Client(std::shared_ptr<::grpc::Channel> channel, RetryStrategy retry_strategy)
       : channel_(channel),
         client_context_(common::make_unique<::grpc::ClientContext>()),
-        rpc_method_name_(
-            RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name()),
-        rpc_method_(rpc_method_name_.c_str(),
-                    RpcType<typename RpcHandlerType::IncomingType,
-                            typename RpcHandlerType::OutgoingType>::value,
+        rpc_method_name_(RpcServiceMethod::MethodName()),
+        rpc_method_(rpc_method_name_.c_str(), RpcServiceMethod::StreamType,
                     channel_),
         retry_strategy_(retry_strategy) {
     CHECK(!retry_strategy ||
@@ -48,14 +50,11 @@ class Client {
   Client(std::shared_ptr<::grpc::Channel> channel)
       : channel_(channel),
         client_context_(common::make_unique<::grpc::ClientContext>()),
-        rpc_method_name_(
-            RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name()),
-        rpc_method_(rpc_method_name_.c_str(),
-                    RpcType<typename RpcHandlerType::IncomingType,
-                            typename RpcHandlerType::OutgoingType>::value,
+        rpc_method_name_(RpcServiceMethod::MethodName()),
+        rpc_method_(rpc_method_name_.c_str(), RpcServiceMethod::StreamType,
                     channel_) {}
 
-  bool StreamRead(typename RpcHandlerType::ResponseType *response) {
+  bool StreamRead(ResponseType *response) {
     switch (rpc_method_.method_type()) {
       case ::grpc::internal::RpcMethod::BIDI_STREAMING:
         InstantiateClientReaderWriterIfNeeded();
@@ -64,16 +63,15 @@ class Client {
         CHECK(client_reader_);
         return client_reader_->Read(response);
       default:
-        LOG(FATAL)
-            << "This method is for server or bidirectional streaming RPC only.";
+        LOG(FATAL) << "This method is for server or bidirectional streaming "
+                      "RPC only.";
     }
   }
 
-  bool Write(const typename RpcHandlerType::RequestType &request) {
-    return RetryWithStrategy(
-        retry_strategy_,
-        std::bind(&Client<RpcHandlerType>::WriteImpl, this, request),
-        std::bind(&Client<RpcHandlerType>::Reset, this));
+  bool Write(const RequestType &request) {
+    return RetryWithStrategy(retry_strategy_,
+                             [this, &request] { return WriteImpl(request); },
+                             [this] { Reset(); });
   }
 
   bool StreamWritesDone() {
@@ -85,8 +83,8 @@ class Client {
         InstantiateClientReaderWriterIfNeeded();
         return client_reader_writer_->WritesDone();
       default:
-        LOG(FATAL)
-            << "This method is for client or bidirectional streaming RPC only.";
+        LOG(FATAL) << "This method is for client or bidirectional streaming "
+                      "RPC only.";
     }
   }
 
@@ -106,7 +104,7 @@ class Client {
     }
   }
 
-  const typename RpcHandlerType::ResponseType &response() {
+  const ResponseType &response() {
     CHECK(rpc_method_.method_type() ==
               ::grpc::internal::RpcMethod::NORMAL_RPC ||
           rpc_method_.method_type() ==
@@ -119,7 +117,7 @@ class Client {
     client_context_ = common::make_unique<::grpc::ClientContext>();
   }
 
-  bool WriteImpl(const typename RpcHandlerType::RequestType &request) {
+  bool WriteImpl(const RequestType &request) {
     switch (rpc_method_.method_type()) {
       case ::grpc::internal::RpcMethod::NORMAL_RPC:
         return MakeBlockingUnaryCall(request, &response_).ok();
@@ -141,10 +139,8 @@ class Client {
              ::grpc::internal::RpcMethod::CLIENT_STREAMING);
     if (!client_writer_) {
       client_writer_.reset(
-          ::grpc::internal::
-              ClientWriterFactory<typename RpcHandlerType::RequestType>::Create(
-                  channel_.get(), rpc_method_, client_context_.get(),
-                  &response_));
+          ::grpc::internal::ClientWriterFactory<RequestType>::Create(
+              channel_.get(), rpc_method_, client_context_.get(), &response_));
     }
   }
 
@@ -154,27 +150,21 @@ class Client {
     if (!client_reader_writer_) {
       client_reader_writer_.reset(
           ::grpc::internal::ClientReaderWriterFactory<
-              typename RpcHandlerType::RequestType,
-              typename RpcHandlerType::ResponseType>::Create(channel_.get(),
-                                                             rpc_method_,
-                                                             client_context_
-                                                                 .get()));
+              RequestType, ResponseType>::Create(channel_.get(), rpc_method_,
+                                                 client_context_.get()));
     }
   }
 
-  void InstantiateClientReader(
-      const typename RpcHandlerType::RequestType &request) {
+  void InstantiateClientReader(const RequestType &request) {
     CHECK_EQ(rpc_method_.method_type(),
              ::grpc::internal::RpcMethod::SERVER_STREAMING);
     client_reader_.reset(
-        ::grpc::internal::
-            ClientReaderFactory<typename RpcHandlerType::ResponseType>::Create(
-                channel_.get(), rpc_method_, client_context_.get(), request));
+        ::grpc::internal::ClientReaderFactory<ResponseType>::Create(
+            channel_.get(), rpc_method_, client_context_.get(), request));
   }
 
-  ::grpc::Status MakeBlockingUnaryCall(
-      const typename RpcHandlerType::RequestType &request,
-      typename RpcHandlerType::ResponseType *response) {
+  ::grpc::Status MakeBlockingUnaryCall(const RequestType &request,
+                                       ResponseType *response) {
     CHECK_EQ(rpc_method_.method_type(),
              ::grpc::internal::RpcMethod::NORMAL_RPC);
     return ::grpc::internal::BlockingUnaryCall(
@@ -186,15 +176,11 @@ class Client {
   const std::string rpc_method_name_;
   const ::grpc::internal::RpcMethod rpc_method_;
 
-  std::unique_ptr<::grpc::ClientWriter<typename RpcHandlerType::RequestType>>
-      client_writer_;
-  std::unique_ptr<
-      ::grpc::ClientReaderWriter<typename RpcHandlerType::RequestType,
-                                 typename RpcHandlerType::ResponseType>>
+  std::unique_ptr<::grpc::ClientWriter<RequestType>> client_writer_;
+  std::unique_ptr<::grpc::ClientReaderWriter<RequestType, ResponseType>>
       client_reader_writer_;
-  std::unique_ptr<::grpc::ClientReader<typename RpcHandlerType::ResponseType>>
-      client_reader_;
-  typename RpcHandlerType::ResponseType response_;
+  std::unique_ptr<::grpc::ClientReader<ResponseType>> client_reader_;
+  ResponseType response_;
   RetryStrategy retry_strategy_;
 };
 

--- a/cpp_grpc/rpc_handler.h
+++ b/cpp_grpc/rpc_handler.h
@@ -20,20 +20,22 @@
 #include "cpp_grpc/execution_context.h"
 #include "cpp_grpc/rpc.h"
 #include "cpp_grpc/rpc_handler_interface.h"
-#include "cpp_grpc/type_traits.h"
-#include "glog/logging.h"
+#include "cpp_grpc/rpc_service_method_traits.h"
+
 #include "google/protobuf/message.h"
+
+#include "glog/logging.h"
+
 #include "grpc++/grpc++.h"
 
 namespace cpp_grpc {
 
-template <typename Incoming, typename Outgoing>
+template <typename RpcServiceMethodConcept>
 class RpcHandler : public RpcHandlerInterface {
  public:
-  using IncomingType = Incoming;
-  using OutgoingType = Outgoing;
-  using RequestType = StripStream<Incoming>;
-  using ResponseType = StripStream<Outgoing>;
+  using RpcServiceMethod = RpcServiceMethodTraits<RpcServiceMethodConcept>;
+  using RequestType = typename RpcServiceMethod::RequestType;
+  using ResponseType = typename RpcServiceMethod::ResponseType;
 
   class Writer {
    public:

--- a/cpp_grpc/rpc_handler_interface.h
+++ b/cpp_grpc/rpc_handler_interface.h
@@ -17,8 +17,8 @@
 #ifndef CPP_GRPC_RPC_HANDLER_INTERFACE_H_
 #define CPP_GRPC_RPC_HANDLER_INTERFACE_H_
 
-#include "cpp_grpc/execution_context.h"
 #include "cpp_grpc/common/make_unique.h"
+#include "cpp_grpc/execution_context.h"
 #include "google/protobuf/message.h"
 #include "grpc++/grpc++.h"
 
@@ -28,12 +28,6 @@ class Rpc;
 class RpcHandlerInterface {
  public:
   virtual ~RpcHandlerInterface() = default;
-  // Returns the fully qualified name of the gRPC method this handler is
-  // implementing. The fully qualified name has the structure
-  // '/<<full service name>>/<<method name>>', where the service name is the
-  // fully qualified proto package name of the service and method name the name
-  // of the method as defined in the service definition of the proto.
-  virtual std::string method_name() const = 0;
   virtual void SetExecutionContext(ExecutionContext* execution_context) = 0;
   virtual void SetRpc(Rpc* rpc) = 0;
   virtual void OnRequestInternal(

--- a/cpp_grpc/rpc_service_method_traits.h
+++ b/cpp_grpc/rpc_service_method_traits.h
@@ -1,0 +1,73 @@
+#ifndef CPP_GRPC_RPC_SERVICE_METHOD_TRAITS_H
+#define CPP_GRPC_RPC_SERVICE_METHOD_TRAITS_H
+
+#include "cpp_grpc/type_traits.h"
+
+namespace cpp_grpc {
+
+DEFINE_HAS_SIGNATURE(has_service_method_name, T::MethodName,
+                     const char* (*)(void));
+
+DEFINE_HAS_MEMBER_TYPE(has_incoming_type, IncomingType);
+DEFINE_HAS_MEMBER_TYPE(has_outgoing_type, OutgoingType);
+
+// The RPC service method concept describes types from which properties of an
+// RPC service can be inferred. The type RpcServiceMethod satisfies the RPC
+// service concept if:
+//   1) it provides a static member function ' const char* MethodName()'
+//   2) it provides an 'IncomingType' typedef; i.e. the proto message passed to
+//      the service method
+//   3) it provides an 'OutgoingType' typedef; i.e. the proto message passed to
+//      the service method
+// Note: the IncomingType and OutgoingType specified above may be wrapped (or
+//       tagged) by cpp_grpc::Stream.
+template <typename RpcServiceMethodConcept>
+struct RpcServiceMethodTraits {
+  static_assert(has_service_method_name<RpcServiceMethodConcept>::value,
+                "The RPC service method concept must provide a static member "
+                "'const char* MethodName()'.");
+
+  static_assert(has_incoming_type<RpcServiceMethodConcept>::value,
+                "The RPC service method concept must provide an IncomingType.");
+
+  static_assert(has_outgoing_type<RpcServiceMethodConcept>::value,
+                "The RPC service method concept must provide an OutgoingType.");
+
+  // Returns the fully qualified name of the gRPC method this handler is
+  // implementing. The fully qualified name has the structure
+  // '/<<full service name>>/<<method name>>', where the service name is the
+  // fully qualified proto package name of the service and method name the
+  // name of the method as defined in the service definition of the proto.
+  static constexpr const char* MethodName() {
+    return RpcServiceMethodConcept::MethodName();
+  }
+
+  // An object derived from ::google::protobuf::Message which is passed to a
+  // specific service method.
+  using RequestType =
+      StripStream<typename RpcServiceMethodConcept::IncomingType>;
+
+  // An object derived from ::google::protobuf::Message which is returned from a
+  // specific service method.
+  using ResponseType =
+      StripStream<typename RpcServiceMethodConcept::OutgoingType>;
+
+  static_assert(
+      std::is_base_of<::google::protobuf::Message, RequestType>::value,
+      "The RPC request type must be derived from ::google::protobuf::Message.");
+
+  static_assert(
+      std::is_base_of<::google::protobuf::Message, ResponseType>::value,
+      "The RPC response type must be derived from "
+      "::google::protobuf::Message.");
+
+  // The streaming type of the service method. See also
+  // ::grpc::internal::RpcMethod.
+  static constexpr auto StreamType =
+      RpcType<typename RpcServiceMethodConcept::IncomingType,
+              typename RpcServiceMethodConcept::OutgoingType>::value;
+};
+
+}  // namespace cpp_grpc
+
+#endif  // CPP_GRPC_RPC_SERVICE_METHOD_TRAITS_H

--- a/cpp_grpc/server.h
+++ b/cpp_grpc/server.h
@@ -23,12 +23,12 @@
 #include <string>
 #include <thread>
 
+#include "cpp_grpc/common/make_unique.h"
 #include "cpp_grpc/completion_queue_thread.h"
 #include "cpp_grpc/event_queue_thread.h"
 #include "cpp_grpc/execution_context.h"
 #include "cpp_grpc/rpc_handler.h"
 #include "cpp_grpc/service.h"
-#include "cpp_grpc/common/make_unique.h"
 #include "grpc++/grpc++.h"
 
 namespace cpp_grpc {
@@ -56,8 +56,7 @@ class Server {
 
     template <typename RpcHandlerType>
     void RegisterHandler() {
-      std::string method_full_name =
-          RpcHandlerInterface::Instantiate<RpcHandlerType>()->method_name();
+      std::string method_full_name = RpcHandlerType::MethodName();
       std::string service_full_name;
       std::string method_name;
       std::tie(service_full_name, method_name) =

--- a/cpp_grpc/server_test.cc
+++ b/cpp_grpc/server_test.cc
@@ -27,7 +27,6 @@
 #include "grpc++/grpc++.h"
 #include "gtest/gtest.h"
 
-
 namespace cpp_grpc {
 namespace {
 
@@ -175,8 +174,8 @@ TEST_F(ServerTest, ProcessRpcStreamTest) {
     request.set_input(i);
     EXPECT_TRUE(client.Write(request));
   }
-  EXPECT_TRUE(client.WritesDone());
-  EXPECT_TRUE(client.Finish().ok());
+  EXPECT_TRUE(client.StreamWritesDone());
+  EXPECT_TRUE(client.StreamFinish().ok());
   EXPECT_EQ(client.response().output(), 33);
 
   server_->Shutdown();
@@ -203,15 +202,15 @@ TEST_F(ServerTest, ProcessBidiStreamingRpcTest) {
     request.set_input(i);
     EXPECT_TRUE(client.Write(request));
   }
-  client.WritesDone();
+  client.StreamWritesDone();
   proto::GetSumResponse response;
   std::list<int> expected_responses = {0, 0, 1, 1, 3, 3};
-  while (client.Read(&response)) {
+  while (client.StreamRead(&response)) {
     EXPECT_EQ(expected_responses.front(), response.output());
     expected_responses.pop_front();
   }
   EXPECT_TRUE(expected_responses.empty());
-  EXPECT_TRUE(client.Finish().ok());
+  EXPECT_TRUE(client.StreamFinish().ok());
 
   server_->Shutdown();
 }
@@ -249,11 +248,11 @@ TEST_F(ServerTest, ProcessServerStreamingRpcTest) {
   client.Write(request);
   proto::GetSequenceResponse response;
   for (int i = 0; i < 12; ++i) {
-    EXPECT_TRUE(client.Read(&response));
+    EXPECT_TRUE(client.StreamRead(&response));
     EXPECT_EQ(response.output(), i);
   }
-  EXPECT_FALSE(client.Read(&response));
-  EXPECT_TRUE(client.Finish().ok());
+  EXPECT_FALSE(client.StreamRead(&response));
+  EXPECT_TRUE(client.StreamFinish().ok());
 
   server_->Shutdown();
 }

--- a/cpp_grpc/server_test.cc
+++ b/cpp_grpc/server_test.cc
@@ -41,9 +41,10 @@ class MathServerContext : public ExecutionContext {
 class GetSumHandler
     : public RpcHandler<Stream<proto::GetSumRequest>, proto::GetSumResponse> {
  public:
-  std::string method_name() const override {
+  static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetSum";
   }
+
   void OnRequest(const proto::GetSumRequest& request) override {
     sum_ += GetContext<MathServerContext>()->additional_increment();
     sum_ += request.input();
@@ -62,9 +63,10 @@ class GetSumHandler
 class GetRunningSumHandler : public RpcHandler<Stream<proto::GetSumRequest>,
                                                Stream<proto::GetSumResponse>> {
  public:
-  std::string method_name() const override {
+  static const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetRunningSum";
   }
+
   void OnRequest(const proto::GetSumRequest& request) override {
     sum_ += request.input();
 
@@ -86,12 +88,15 @@ class GetRunningSumHandler : public RpcHandler<Stream<proto::GetSumRequest>,
 class GetSquareHandler
     : public RpcHandler<proto::GetSquareRequest, proto::GetSquareResponse> {
  public:
-  std::string method_name() const override {
+  static const char* MethodName() {
+    std::cout << "methodname\n";
     return "/cpp_grpc.proto.Math/GetSquare";
   }
+
   void OnRequest(const proto::GetSquareRequest& request) override {
     auto response = common::make_unique<proto::GetSquareResponse>();
     response->set_output(request.input() * request.input());
+    std::cout << "on request: " << request.input() << std::endl;
     Send(std::move(response));
   }
 };
@@ -99,9 +104,8 @@ class GetSquareHandler
 class GetEchoHandler
     : public RpcHandler<proto::GetEchoRequest, proto::GetEchoResponse> {
  public:
-  std::string method_name() const override {
-    return "/cpp_grpc.proto.Math/GetEcho";
-  }
+  static const char* MethodName() { return "/cpp_grpc.proto.Math/GetEcho"; }
+
   void OnRequest(const proto::GetEchoRequest& request) override {
     int value = request.input();
     Writer writer = GetWriter();
@@ -118,9 +122,10 @@ class GetSequenceHandler
     : public RpcHandler<proto::GetSequenceRequest,
                         Stream<proto::GetSequenceResponse>> {
  public:
-  std::string method_name() const override {
+  static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetSequence";
   }
+
   void OnRequest(const proto::GetSequenceRequest& request) override {
     for (int i = 0; i < request.input(); ++i) {
       auto response = common::make_unique<proto::GetSequenceResponse>();

--- a/cpp_grpc/server_test.cc
+++ b/cpp_grpc/server_test.cc
@@ -38,13 +38,16 @@ class MathServerContext : public ExecutionContext {
   std::promise<EchoResponder> echo_responder;
 };
 
-class GetSumHandler
-    : public RpcHandler<Stream<proto::GetSumRequest>, proto::GetSumResponse> {
- public:
+struct GetSumMethod {
   static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetSum";
   }
+  using IncomingType = Stream<proto::GetSumRequest>;
+  using OutgoingType = proto::GetSumResponse;
+};
 
+class GetSumHandler : public RpcHandler<GetSumMethod> {
+ public:
   void OnRequest(const proto::GetSumRequest& request) override {
     sum_ += GetContext<MathServerContext>()->additional_increment();
     sum_ += request.input();
@@ -60,13 +63,16 @@ class GetSumHandler
   int sum_ = 0;
 };
 
-class GetRunningSumHandler : public RpcHandler<Stream<proto::GetSumRequest>,
-                                               Stream<proto::GetSumResponse>> {
- public:
-  static const char* MethodName() {
+struct GetRunningSumMethod {
+  static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetRunningSum";
   }
+  using IncomingType = Stream<proto::GetSumRequest>;
+  using OutgoingType = Stream<proto::GetSumResponse>;
+};
 
+class GetRunningSumHandler : public RpcHandler<GetRunningSumMethod> {
+ public:
   void OnRequest(const proto::GetSumRequest& request) override {
     sum_ += request.input();
 
@@ -85,14 +91,16 @@ class GetRunningSumHandler : public RpcHandler<Stream<proto::GetSumRequest>,
   int sum_ = 0;
 };
 
-class GetSquareHandler
-    : public RpcHandler<proto::GetSquareRequest, proto::GetSquareResponse> {
- public:
-  static const char* MethodName() {
-    std::cout << "methodname\n";
+struct GetSquareMethod {
+  static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetSquare";
   }
+  using IncomingType = proto::GetSquareRequest;
+  using OutgoingType = proto::GetSquareResponse;
+};
 
+class GetSquareHandler : public RpcHandler<GetSquareMethod> {
+ public:
   void OnRequest(const proto::GetSquareRequest& request) override {
     auto response = common::make_unique<proto::GetSquareResponse>();
     response->set_output(request.input() * request.input());
@@ -101,11 +109,16 @@ class GetSquareHandler
   }
 };
 
-class GetEchoHandler
-    : public RpcHandler<proto::GetEchoRequest, proto::GetEchoResponse> {
- public:
-  static const char* MethodName() { return "/cpp_grpc.proto.Math/GetEcho"; }
+struct GetEchoMethod {
+  static constexpr const char* MethodName() {
+    return "/cpp_grpc.proto.Math/GetEcho";
+  }
+  using IncomingType = proto::GetEchoRequest;
+  using OutgoingType = proto::GetEchoResponse;
+};
 
+class GetEchoHandler : public RpcHandler<GetEchoMethod> {
+ public:
   void OnRequest(const proto::GetEchoRequest& request) override {
     int value = request.input();
     Writer writer = GetWriter();
@@ -118,14 +131,16 @@ class GetEchoHandler
   }
 };
 
-class GetSequenceHandler
-    : public RpcHandler<proto::GetSequenceRequest,
-                        Stream<proto::GetSequenceResponse>> {
- public:
+struct GetSequenceMethod {
   static constexpr const char* MethodName() {
     return "/cpp_grpc.proto.Math/GetSequence";
   }
+  using IncomingType = proto::GetSequenceRequest;
+  using OutgoingType = Stream<proto::GetSequenceResponse>;
+};
 
+class GetSequenceHandler : public RpcHandler<GetSequenceMethod> {
+ public:
   void OnRequest(const proto::GetSequenceRequest& request) override {
     for (int i = 0; i < request.input(); ++i) {
       auto response = common::make_unique<proto::GetSequenceResponse>();
@@ -173,7 +188,7 @@ TEST_F(ServerTest, ProcessRpcStreamTest) {
   server_->SetExecutionContext(common::make_unique<MathServerContext>());
   server_->Start();
 
-  Client<GetSumHandler> client(client_channel_);
+  Client<GetSumMethod> client(client_channel_);
   for (int i = 0; i < 3; ++i) {
     proto::GetSumRequest request;
     request.set_input(i);
@@ -189,7 +204,7 @@ TEST_F(ServerTest, ProcessRpcStreamTest) {
 TEST_F(ServerTest, ProcessUnaryRpcTest) {
   server_->Start();
 
-  Client<GetSquareHandler> client(client_channel_);
+  Client<GetSquareMethod> client(client_channel_);
   proto::GetSquareRequest request;
   request.set_input(11);
   EXPECT_TRUE(client.Write(request));
@@ -201,7 +216,7 @@ TEST_F(ServerTest, ProcessUnaryRpcTest) {
 TEST_F(ServerTest, ProcessBidiStreamingRpcTest) {
   server_->Start();
 
-  Client<GetRunningSumHandler> client(client_channel_);
+  Client<GetRunningSumMethod> client(client_channel_);
   for (int i = 0; i < 3; ++i) {
     proto::GetSumRequest request;
     request.set_input(i);
@@ -233,7 +248,7 @@ TEST_F(ServerTest, WriteFromOtherThread) {
     CHECK(responder());
   });
 
-  Client<GetEchoHandler> client(client_channel_);
+  Client<GetEchoMethod> client(client_channel_);
   proto::GetEchoRequest request;
   request.set_input(13);
   EXPECT_TRUE(client.Write(request));
@@ -246,7 +261,7 @@ TEST_F(ServerTest, WriteFromOtherThread) {
 TEST_F(ServerTest, ProcessServerStreamingRpcTest) {
   server_->Start();
 
-  Client<GetSequenceHandler> client(client_channel_);
+  Client<GetSequenceMethod> client(client_channel_);
   proto::GetSequenceRequest request;
   request.set_input(12);
 

--- a/cpp_grpc/type_traits.h
+++ b/cpp_grpc/type_traits.h
@@ -19,6 +19,50 @@
 
 #include <grpc++/grpc++.h>
 
+#include <cstdint>
+#include <type_traits>
+
+// This helper allows us to stamp out traits structs which allow to check for
+// the existence of member functions.
+// Example:
+//   struct Foo { static char* foo() { return nullptr; } };
+//   DEFINE_HAS_SIGNATURE(has_foo, T::foo, char*(*)(void));
+//   static_assert(has_foo_v<Foo>, "foo() is not implemented")
+#define DEFINE_HAS_SIGNATURE(traitsName, funcName, signature)                  \
+  template <typename U>                                                        \
+  class traitsName {                                                           \
+   private:                                                                    \
+    template <typename T, T>                                                   \
+    struct helper;                                                             \
+                                                                               \
+    template <typename T>                                                      \
+    static std::uint8_t check(helper<signature, &funcName>*);                  \
+    template <typename T>                                                      \
+    static std::uint16_t check(...);                                           \
+                                                                               \
+   public:                                                                     \
+    static constexpr bool value = sizeof(check<U>(0)) == sizeof(std::uint8_t); \
+  };
+
+#define DEFINE_HAS_MEMBER_TYPE(traitsName, Type)           \
+  template <class T>                                       \
+  class traitsName {                                       \
+   private:                                                \
+    struct Fallback {                                      \
+      struct Type {};                                      \
+    };                                                     \
+    struct Derived : T, Fallback {};                       \
+                                                           \
+    template <class U>                                     \
+    static std::uint16_t& check(typename U::Type*);        \
+    template <typename U>                                  \
+    static std::uint8_t& check(U*);                        \
+                                                           \
+   public:                                                 \
+    static constexpr bool value =                          \
+        sizeof(check<Derived>(0)) == sizeof(std::uint8_t); \
+  };
+
 namespace cpp_grpc {
 
 template <typename Request>


### PR DESCRIPTION
Introduced RpcServiceMethodConcept which allows to loosen the coupling between the Client and Server implenentations.
Adapted error messages of the Client and modified its interface names to reflect that they are related to streaming RPC calls.